### PR TITLE
Increase minimal required atom version to 1.13 because of #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/hax/atom-elastic-tabstops",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.5.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
> Please note that once you change your style sheets to remove the deprecated shadow DOM selectors, they will no longer be compatible with versions of Atom prior to 1.13. As such, we recommend that package and theme authors set the Atom version to >= 1.13 in the engines section of their packages’ package.json to prevent the upgraded packages from being installed on older versions of Atom.
(http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html)

Because of #14 